### PR TITLE
Fix method call

### DIFF
--- a/framework/src/play/src/main/scala/play/api/data/Form.scala
+++ b/framework/src/play/src/main/scala/play/api/data/Form.scala
@@ -432,7 +432,7 @@ case class FormError(key: String, messages: Seq[String], args: Seq[Any] = Nil) {
    * Displays the formatted message, for use in a template.
    */
   def format(implicit messages: play.api.i18n.Messages): String = {
-    messages.apply(message, args)
+    messages.apply(message, args: _*)
   }
 }
 


### PR DESCRIPTION
```
The FormError.format method should call messages.apply(message, args: _*) instead of messages.apply(message, args) in order to properly format the values of the arguments.
```

`def apply(key: String, args: Any*)` に対して `Seq`を渡してしまうと `Any`のせいで`Seq`の可変長引数として受け取ってしまう。(`WrappedArray[Seq[_]]`)
なので、可変長引数(WrappedArray)として渡すために`_*`を追加。

- [x] メソッド呼び出しを対応
- [x] テストの追加
  - [x] 修正前のコードでは以下のエラーとなる事を確認

```
[error]    {"number":"minimum WrappedArray(0)!"} != {"number":["minimum 0!"]} (FormSpec.scala:302)
[error] Actual:   ...ber":[]"m...m [WrappedArray(]0[)]!"[]}
[error] Expected: ...ber":[]"m...m []0[]!"[]
```
